### PR TITLE
Fixed: Empty parameter causing "ERROR: Fixed output name but more than one file to download"

### DIFF
--- a/nrk-dl.ps1
+++ b/nrk-dl.ps1
@@ -130,7 +130,7 @@ if ($DisableSSLCertVerify) {
     $ytdl_parameters = '--no-check-certificate'
 }
 else {
-    $ytdl_parameters = ''
+    $ytdl_parameters = $null
 }
 
 if ($IsMacOS -or $IsLinux) {


### PR DESCRIPTION
When -DisableSSLCertVerify was not used, the script added an empty string ('') onto the end of the command, causing the script to mistake it for a second download link.

I've replaced this empty string with ($null), so that if -DisableSSLCertVerify is not being used, the script doesn't add any extra parameter to the yt-dlp command.