### PR TITLE
Fixed: Empty parameter causing "ERROR: Fixed output name but more tha…

### DIFF
--- a/nrk-dl.ps1
+++ b/nrk-dl.ps1
@@ -130,7 +130,7 @@ if ($DisableSSLCertVerify) {
     $ytdl_parameters = '--no-check-certificate'
 }
 else {
-    $ytdl_parameters = ''
+    $ytdl_parameters = $null
 }
 
 if ($IsMacOS -or $IsLinux) {


### PR DESCRIPTION
…n one file to download"

When -DisableSSLCertVerify was not used, the script added an empty string ('') onto the end of the command, causing the script to mistake it for a second download link.

I've replaced this empty string with ($null), so that if -DisableSSLCertVerify is not being used, the script doesn't add any extra parameter to the yt-dlp command.

This is a proper implementation of [Pull request #10 ](https://github.com/ljskatt/nrk-dl/pull/10) without the empty whitespace problems I had at the end of that commit.