### PR TITLE
Various updates and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Lovligheten rundt dette verktøyet er uklart, anbefaler å bare benytte verktøyet til privat, ikke-kommersiell bruk.<br>
 **Bruk av verktøyet gjøres på egen risiko.** [Opphavsrett på NRK](https://www.nrk.no/etikk/opphavsrett-pa-nrk.no-1.2843522)
 
-Dette prosjektet ble startet etter at det ble kjent at NRK innhold fra før 1997 kan bli borte fra NRK om det ikke kommer en ny avtale på plass med Norwaco, derfor bestemte jeg meg for å lage et script som gjør at man lett kan laste ned innehold fra NRK, slik at man kan holde på denne arven.
+Dette prosjektet ble startet etter at det ble kjent at NRK innhold fra før 1997 kan bli borte fra NRK om det ikke kommer en ny avtale på plass med Norwaco, derfor bestemte jeg meg for å lage et script som gjør at man lett kan laste ned innhold fra NRK, slik at man kan holde på denne arven.
 
-Avtalen med Norwaco ble fornyet, derfor ble motivet til dette prosjeket endret til å fokusere på å laste ned programmer/serier som stadig blir fjernet fra NRK sitt arkiv, rapporter over hvilke programmer/serier som blir fjernet, kan du finne her: [NRK-Expire](https://github.com/ljskatt/nrk-expire)
+Avtalen med Norwaco ble fornyet, derfor ble motivet til dette prosjektet endret til å fokusere på å laste ned programmer/serier som stadig blir fjernet fra NRK sitt arkiv, rapporter over hvilke programmer/serier som blir fjernet, kan du finne her: [NRK-Expire](https://github.com/ljskatt/nrk-expire)
 
 ## Windows
 
@@ -14,7 +14,7 @@ Avtalen med Norwaco ble fornyet, derfor ble motivet til dette prosjeket endret t
 Dette vil automatisk bli lastet ned når du kjører scriptet:
 
 - yt-dlp.exe - Denne pakken gjør at man kan laste ned videofilene fra NRK sine servere
-- ffmpeg.exe - yt-dlp benytter dette programmet når det evenuelt er problemer med video eller lyd
+- ffmpeg.exe - yt-dlp benytter dette programmet når det skal slå sammen video og lyd
 
 ### Start
 
@@ -25,9 +25,12 @@ Last ned filen og kjør kommandoen for å begynne å laste ned episoden/episoder
 ### Eksempel
 
 ```
+https://tv.nrk.no/program/FDRI40003290
 https://tv.nrk.no/serie/fleksnes
-https://tv.nrk.no/program/KOID20001420
 ```
+
+`.\nrk-dl.ps1 "FDRI40003290"`
+Scriptet vil laste ned programmet
 
 `.\nrk-dl.ps1 "fleksnes"`
 Scriptet vil laste ned alle episodene av Fleksnes
@@ -35,16 +38,13 @@ Scriptet vil laste ned alle episodene av Fleksnes
 `.\nrk-dl.ps1 "fantorangen" -SeasonFilter 3`
 Scriptet vil laste ned alle episodene av Fantorangen i sesong 3
 
-`.\nrk-dl.ps1 "KOID20001420"`
-Scriptet vil laste ned programmet
-
 ### Alignment filer
 
 - [x] Poirot - [Issue](https://github.com/ljskatt/nrk-dl/issues/5)
 - [ ] Vera - [Issue](https://github.com/ljskatt/nrk-dl/issues/4)
 
 ## Linux
-:warning: &nbsp; Dette scriptet fungerer ikke lenger, dette blir oppdatert fortløpende, men Powershell (Windows) er prioritert først :warning:
+:warning: &nbsp; Dette scriptet fungerer ikke lenger, dette blir oppdatert fortløpende, men PowerShell (Windows) er prioritert først :warning:
 
 ### Dependencies
 
@@ -52,8 +52,8 @@ Dette vil automatisk bli lastet ned når du kjører scriptet (Støtter Debian-ba
 
 - yt-dlp - Denne pakken gjør at man kan laste ned videofilen fra NRK sine servere
 - curl - Denne pakken trenger man for å kunne kommunisere med NRK sitt API
-- jq - Denne pakken brukes til å hente ut informasjon fra responsen til NRK sitt api
-- screen - Denne pakken brukes når man laster ned parallellt
+- jq - Denne pakken brukes til å hente ut informasjon fra responsen til NRK sitt API
+- screen - Denne pakken brukes når man laster ned parallelt
 
 ### Start
 Scriptet kan startes med å bare kjøre det, eller legge til flere parametere i kommandoen slik at man kjappere kan laste ned flere serier/programmer.
@@ -63,7 +63,7 @@ Scriptet kan startes med å bare kjøre det, eller legge til flere parametere i 
 
 ### Parametere
 
-- Kjøre det parallellt: (0/1)
+- Kjøre det parallelt: (0/1)
 - Hvor mange nedlastninger skal kjøre samtidig: (2-99)
 - Program: (program)
 
@@ -74,7 +74,7 @@ Scriptet kan startes med å bare kjøre det, eller legge til flere parametere i 
 
 `./nrk-dl.sh "1" "5" "fleksnes"`
 
-Nedlastningen vil kjøre parallellt med 5 samtidige nedlastninger av Fleksnes
+Nedlastningen vil kjøre parallelt med 5 samtidige nedlastninger av Fleksnes
 
 <br>
 

--- a/nrk-dl.ps1
+++ b/nrk-dl.ps1
@@ -33,7 +33,7 @@ param (
 
     [Parameter()]
     [switch]
-    $DisableSSLCertVerify, # This will only affect yt-dlp downloads and not connection to NRK api, SHOULD ONLY BE USED IF YOU GET ERRORS LIKE: [SSL: CERTIFICATE_VERIFY_FAILED]
+    $DisableSSLCertVerify, # This will only affect yt-dlp downloads and not connection to NRK API, SHOULD ONLY BE USED IF YOU GET ERRORS LIKE: [SSL: CERTIFICATE_VERIFY_FAILED]
 
     [Parameter()]
     [switch]
@@ -163,7 +163,7 @@ else {
     if (-not (Test-Path -Path "C:\Windows\System32\MSVCR100.dll" -PathType "leaf")) {
         Write-Host -Object ""
         Write-Host -BackgroundColor "Red" -ForegroundColor "White" -Object " MSVCR100.dll (required by yt-dlp) is missing, please install missing C++ library: " -NoNewline; Write-Host -ForegroundColor "DarkGray" -Object "|"
-        Write-Host -BackgroundColor "Red" -ForegroundColor "White" -Object " https://www.microsoft.com/en-US/download/details.aspx?id=8328 " -NoNewline; Write-Host -ForegroundColor "DarkGray" -Object "|"
+        Write-Host -BackgroundColor "Red" -ForegroundColor "White" -Object " https://www.microsoft.com/en-US/download/details.aspx?id=26999 " -NoNewline; Write-Host -ForegroundColor "DarkGray" -Object "|"
         Write-Host -Object ""
     }
 }

--- a/nrk-dl.ps1
+++ b/nrk-dl.ps1
@@ -179,12 +179,37 @@ if ($IsMacOS -or $IsLinux) {
 else {
     if (-not (Test-Path -PathType "Leaf" -Path "ffmpeg.exe")) {
         $downloadaccept = $null
-        $downloadaccept = Read-Host -Prompt "ffmpeg.exe (required-package) is not installed, do you want us to download it? Source: https://cdn.serverhost.no/ljskatt/ffmpeg.exe (Y/n)`n"
+        $downloadaccept = Read-Host -Prompt "ffmpeg.exe (required-package) is not installed, do you want us to download it? Source: https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip (Y/n)`n"
         if ($downloadaccept -in '','y','yes') {
             Write-Output "Downloading ffmpeg"
-            Invoke-WebRequest -Uri "https://cdn.serverhost.no/ljskatt/ffmpeg.exe" -OutFile "ffmpeg.exe"
-            if (Test-Path -PathType "Leaf" -Path "ffmpeg.exe") {
-                Write-Host -Object "|" -NoNewline; Write-Host -BackgroundColor "Green" -ForegroundColor "Black" -Object " Success " -NoNewline; Write-Host -Object "|"; Write-Host ""
+            $tempZipPath = "ffmpeg-temp.zip"
+            Invoke-WebRequest -Uri "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip" -OutFile "$tempZipPath"
+            
+            if (Test-Path -PathType "Leaf" -Path "$tempZipPath") {
+                Expand-Archive -Path "$tempZipPath" -DestinationPath "." -Force
+                $extractedFolder = Get-ChildItem -Directory | Where-Object { $_.Name -like "ffmpeg-*-essentials_build" } | Select-Object -First 1
+                
+                if ($extractedFolder -and (Test-Path -PathType "Leaf" -Path "$($extractedFolder.FullName)\bin\ffmpeg.exe")) {
+                    Copy-Item -Path "$($extractedFolder.FullName)\bin\ffmpeg.exe" -Destination "." -Force
+                    Remove-Item -Path "$tempZipPath" -Force
+                    Remove-Item -Path $extractedFolder.FullName -Recurse -Force
+                    
+                    if (Test-Path -PathType "Leaf" -Path "ffmpeg.exe") {
+                        Write-Host -Object "|" -NoNewline; Write-Host -BackgroundColor "Green" -ForegroundColor "Black" -Object " Success " -NoNewline; Write-Host -Object "|"; Write-Host ""
+                    }
+                    else {
+                        Write-Host -Object "|" -NoNewline; Write-Host -BackgroundColor "Red" -ForegroundColor "Black" -Object " Failed " -NoNewline; Write-Host -Object "|"
+                        exit
+                    }
+                }
+                else {
+                    Remove-Item -Path "$tempZipPath" -Force
+                    if ($extractedFolder) {
+                        Remove-Item -Path $extractedFolder.FullName -Recurse -Force
+                    }
+                    Write-Host -Object "|" -NoNewline; Write-Host -BackgroundColor "Red" -ForegroundColor "Black" -Object " Failed " -NoNewline; Write-Host -Object "|"
+                    exit
+                }
             }
             else {
                 Write-Host -Object "|" -NoNewline; Write-Host -BackgroundColor "Red" -ForegroundColor "Black" -Object " Failed " -NoNewline; Write-Host -Object "|"


### PR DESCRIPTION
- Fix "Invoke-RestMethod:" error showing up when title is a program and not a series
- Updated Visual C++ 2010 link, as the old link led to a site that said "We're sorry, this download is no longer available." The new link leads to the newest version of Visual C++ 2010.
- Updated program example, as the old one has been removed and the new example will seemingly stay on NRK TV forever, just like the other two examples.
- Clarified FFmpeg's role within yt-dlp
- Fixed some typos.